### PR TITLE
fix: ensure vitest runner works on Windows

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -71,6 +71,7 @@
    - `pnpm typecheck`
    - `pnpm test` (unit/integration)
    - `pnpm test --coverage`
+   - `pnpm exec playwright install` (одноразовая загрузка браузеров перед e2e/a11y тестами)
    - `pnpm test:e2e` (Playwright, запускает dev-сервер автоматически)
    - `pnpm test:a11y` (axe-core + Playwright)
 6. Завершите работу Supabase после разработки:

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -26,10 +26,11 @@ for (let index = 0; index < rawArgs.length; index += 1) {
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const binary = process.platform === "win32" ? "vitest.cmd" : "vitest";
-const vitestBinPath = resolve(scriptDir, "../node_modules/.bin", binary);
+const vitestEntrypoint = resolve(scriptDir, "../node_modules/vitest/vitest.mjs");
 
-const child = spawn(vitestBinPath, vitestArgs, { stdio: "inherit" });
+const child = spawn(process.execPath, [vitestEntrypoint, ...vitestArgs], {
+  stdio: "inherit",
+});
 
 child.on("exit", (code, signal) => {
   if (signal) {


### PR DESCRIPTION
## Summary
- invoke the Vitest CLI through its ESM entrypoint instead of the platform-specific shim so the custom runner works on Windows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e19ffc8c832e9ff21de14dc55e46